### PR TITLE
Fix dynamic module import error

### DIFF
--- a/src/trajopt/CMakeLists.txt
+++ b/src/trajopt/CMakeLists.txt
@@ -8,7 +8,7 @@ include_directories(
 )
 
 if (NOT APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif()
 
 add_library(trajopt


### PR DESCRIPTION
Fixes https://github.com/joschu/trajopt/issues/47:

ctrajoptpy threw "ImportError: dynamic module does not define init function (initctrajoptpy)" on import. This was due to the "-fvisibility=hidden" compiler flag.
